### PR TITLE
Cleanup tab drop event

### DIFF
--- a/lib/preview-tabs-pane-controller.coffee
+++ b/lib/preview-tabs-pane-controller.coffee
@@ -10,17 +10,11 @@ class PreviewTabsPaneController
     @subscriptions =
       paneItemAdded: @pane.onDidAddItem @_onPaneItemAdded
       treeEntryDoubleClicked: new PreviewTabsEventHandler(atom.workspaceView, "dblclick", ".tree-view .file", @_onTreeEntryDoubleClicked)
-
-    @_deferUntilTabsLoaded =>
-      @tabBar = @paneView.find(".tab-bar")
-      @subscriptions.tabDropped = new PreviewTabsEventHandler(@tabBar, "drop", null, @_onTabDropped)
+      tabDropped: new PreviewTabsEventHandler(@paneView, "drop", ".tab-bar", @_onTabDropped)
 
   remove: ->
     subscription.dispose() for own name, subscription of @subscriptions
     @preview?.destroy()
-
-  _deferUntilTabsLoaded: (callback) ->
-    setTimeout (->callback?()), 1
 
   _onPaneItemAdded: (paneItem) =>
     return unless paneItem.item.buffer?

--- a/spec/preview-tabs-pane-controller-spec.coffee
+++ b/spec/preview-tabs-pane-controller-spec.coffee
@@ -78,6 +78,22 @@ describe "PreviewTabsPaneController", ->
       it "does not send the first item's tab to the preview", ->
         expect(previewTabsPaneController._findTabForEditor(editor).length).toBe 1
 
+    describe "when a tab is dropped into the pane", ->
+      tabBar = null
+
+      beforeEach ->
+        tabBar = $(document.createElement("ul")).addClass("tab-bar")
+        pane.prepend(tabBar)
+
+      afterEach ->
+        tabBar.remove()
+
+      it "keeps the dropped tab", ->
+        pane.addItem(editor)
+        expect(previewTabsPaneController.preview).toBeTruthy()
+        tabBar.trigger("drop")
+        expect(previewTabsPaneController.preview).toBeFalsy()
+
   describe "removing", ->
     subscriptions = null
 


### PR DESCRIPTION
Will merge this if [atom/tabs PR #89](https://github.com/atom/tabs/pull/89) goes through

Currently, the tab-bar-view stops propagation of its drop event. It's tricky for us to bind to that event, because when our PreviewTabsPaneController is instantiated, the tab-bar may not have rendered, yet. This forces us to [delay binding to the event](https://github.com/ahuth/preview-tabs/blob/926d1551cb33dd043bb842c4c17226ad0ccffdfd/lib/preview-tabs-pane-controller.coffee#L14-16).

Should the PR go through in atom/tabs, we can [bind to the drop event normally](https://github.com/ahuth/preview-tabs/blob/926276d4269b6e9abca208d0e36284ff412213be/lib/preview-tabs-pane-controller.coffee#L13), greatly simplifying the PaneController and making it easier to test.
